### PR TITLE
Overhaul of `xml_to_nc.py`

### DIFF
--- a/utils/xml_to_nc.py
+++ b/utils/xml_to_nc.py
@@ -110,25 +110,8 @@ def main(var, infile, outfile,
          time_bounds=':',
          lon_bounds=':',
          lat_bounds=':',
-         level_bounds=':',
-         force_overwrite=False):
-    """Run the program.
-    
-    @param var: The variable to extract from the catalouge.
-    @type  var: string
-    @param input: single or list of input files
-    @type  input: list or string
-    @param output: File to output list of actual netCDF files to
-    @type  output: string
-    @param force: If True then existing files will be overwritten. If false then
-                  they will be skipped.
-    @type  force: boolean
-
-    """
-
-    # Get subset from catalogues
-    if not force_overwrite and os.access(outfile, os.F_OK):
-        return
+         level_bounds=':'):
+    """Run the program."""
 
     cf = cdms2.open(infile)
 
@@ -162,7 +145,6 @@ def main(var, infile, outfile,
     for att in cf.listglobal():
         setattr(cfout, att, cf.attributes[att])
 
-    #cf.close()
     cfout.close()
 
 
@@ -175,31 +157,33 @@ if __name__ == '__main__':
     description = 'Convert a CDAT xml catalogue to a single netCDF file and/or crop temporal and spatial dimensions'
     parser = argparse.ArgumentParser(description=description,
                                      epilog=extra_info,
-                                     argument_default=argparse.SUPPRESS,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument("variable", type=str, help="""Variable to extract. If 'all', all variables will be extracted.""")
     parser.add_argument("infile", type=str, help="Name of input netCDF file or cdscan xml catalogue file")
     parser.add_argument("outfile", type=str, help="Name of output netCDF file")
 
-    parser.add_argument("--time_bounds", type=str, nargs=2, metavar=('START_DATE', 'END_DATE'),default=':',
+    parser.add_argument("--time_bounds", type=str, nargs=2, metavar=('START_DATE', 'END_DATE'),
                         help="Bounds of the time period to extract from infile [default = all times]. Date format is YYYY-MM-DD.")
-    parser.add_argument("--lon_bounds", type=str, nargs=2, metavar=('WEST_LON', 'EAST_LON'), default=':',
+    parser.add_argument("--lon_bounds", type=float, nargs=2, metavar=('WEST_LON', 'EAST_LON'),
                         help="Longitude bounds of the region to extract from infile [default = all longitudes].")
-    parser.add_argument("--lat_bounds", type=str, nargs=2, metavar=('SOUTH_LAT', 'NORTH_LAT'), default=':',
+    parser.add_argument("--lat_bounds", type=float, nargs=2, metavar=('SOUTH_LAT', 'NORTH_LAT'),
                         help="Latitude bounds of the region to extract from infile [default = all latitudes].")
-    parser.add_argument("--level_bounds", type=str, nargs=2, metavar=('BOTTOM_LEVEL', 'TOP_LEVEL'), default=':',
+    parser.add_argument("--level_bounds", type=float, nargs=2, metavar=('BOTTOM_LEVEL', 'TOP_LEVEL'),
                         help="Vertical level bounds of the region to extract from infile [default = all vetical levels].")
 
-    parser.add_argument("-o", "--force", action="store_true", default=False,
-                        help="Force the overwrite of existing outputs")
-
     args = parser.parse_args()
+    
+    pdb.set_trace()
+
+    args.time_bounds = ':' if not args.time_bounds else args.time_bounds
+    args.lon_bounds = ':' if not args.lon_bounds else args.lon_bounds
+    args.lat_bounds = ':' if not args.lat_bounds else args.lat_bounds
+    args.level_bounds = ':' if not args.level_bounds else args.level_bounds
 
     main(args.variable, args.infile, args.outfile,
          time_bounds=args.time_bounds,
          lon_bounds=args.lon_bounds,
          lat_bounds=args.lat_bounds,
-         level_bounds=args.level_bounds,
-         force_overwrite=args.force)
+         level_bounds=args.level_bounds)
 

--- a/utils/xml_to_nc.py
+++ b/utils/xml_to_nc.py
@@ -173,8 +173,6 @@ if __name__ == '__main__':
                         help="Vertical level bounds of the region to extract from infile [default = all vetical levels].")
 
     args = parser.parse_args()
-    
-    pdb.set_trace()
 
     args.time_bounds = ':' if not args.time_bounds else args.time_bounds
     args.lon_bounds = ':' if not args.lon_bounds else args.lon_bounds


### PR DESCRIPTION
I've re-written `xml_to_nc.py` so that it can crop not only the time axis but also longitude, latitude and level. I'm envisaging that it will be our universal cropper that can be used anywhere in a workflow and can act on cdscan xml file catalogs or normal netCDF file. The reason I prefer it to cdo for cropping is that the vertical level cropping in cdo is cumbersome (you can't specify a range of levels in cdo and instead have to specify exactly which levels you'd like).

In doing so I made the following updates/revisions:  
- I upgraded the command line argument handling so that it now uses `argparse`
- I simplified the time axis checking so that it only now checks that it is monotonically increasing. Previously it did some other checks but those limited the scope of the script to monthly or annual timescales. I'm hoping people can use the script for any timescale they like.
- I removed some of the old latitude and longitude checking which catered for versions of cdat < 6.0. CDAT is so old now that nobody is using versions < 6.0.

@captainceramic What do you think? Would you be happy to merge those changes?
